### PR TITLE
Adds two static variable to PrefixQuery to globally control expansions

### DIFF
--- a/src/core/CLucene/search/PrefixQuery.h
+++ b/src/core/CLucene/search/PrefixQuery.h
@@ -23,6 +23,8 @@ CL_NS_DEF(search)
 	class CLUCENE_EXPORT PrefixQuery: public Query {
 	private:
 		CL_NS(index)::Term* prefix;
+		static int max_expansions;
+		static int max_expansion_factor;
 	protected:
 		PrefixQuery(const PrefixQuery& clone);
 	public:
@@ -39,6 +41,21 @@ CL_NS_DEF(search)
 
 		/** Returns the prefix of this query. */
 		CL_NS(index)::Term* getPrefix(bool pointer=true);
+
+		/**
+		 * Sets the max number of expansions performed per prefix.
+		 * It is quite a good idea to add this limit, as otherwise the query will crash if more than
+		 * 1024 clauses are generated for the OR'ed boolean query.
+		 */
+		static void set_max_expansions(int max_expansions);
+
+		/**
+		 * Determines how much longer an actual token compared to the given prefix may be in order to
+		 * use it for expansion.
+		 *
+		 * A token will only be used if it is less or equal to length(prefix) * max_expansion_factor
+		 */
+		static void set_max_expansion_factor(int max_expansion_factor);
 
     Query* combine(CL_NS(util)::ArrayBase<Query*>* queries);
 		Query* rewrite(CL_NS(index)::IndexReader* reader);


### PR DESCRIPTION
PrefixQuery can be quite aggressive when expanding short prefixes. This might result in an unusable query
which has more than 1024 OR clauses). Therefore these variables can limit the total expansions and
also impose a relation between the prefix length and the length of the expanded token. I.e.
it might be wise to only expand to a token which is three times longer, but not to one which is 15 times longer.
This is especially useful for artificially created tokens which combine many words.

By default both limitations are turned off so that the change is backwards compatible.
